### PR TITLE
fix: meta tag indent

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/logo.svg" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>


### PR DESCRIPTION
<img width="788" alt="Screenshot 2023-02-04 at 10 11 26 PM" src="https://user-images.githubusercontent.com/31113245/216799494-8385a773-eadf-4f27-81c7-aeb2dc6b8650.png">
