### PR TITLE
fix(Spinner): properly center align

### DIFF
--- a/src/lib/components/Spinner.svelte
+++ b/src/lib/components/Spinner.svelte
@@ -11,15 +11,22 @@
 		}
 	}
 
-	.spinner:before {
-		content: '';
-		box-sizing: border-box;
-		width: 50px;
-		height: 50px;
-		border-radius: 50%;
+	.spinner {
 		position: fixed;
 		top: 50%;
 		left: 50%;
+		width: 50px;
+		height: 50px;
+		transform: translate(-50%, -50%);
+	}
+
+	.spinner:before {
+		content: '';
+		box-sizing: border-box;
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		border-radius: 50%;
 		border: 4.5px solid transparent;
 		border-top-color: var(--accent-color);
 		animation: spinner 0.6s linear infinite;


### PR DESCRIPTION
### Description

- The current loader, is held to the right, which is due to the positioning of the spinner component.
- The styles have been calculated, changed accordingly to ensure that it's perfectly centered.

### Fixes #57 

### Screenshot

Here's a screenshot to show the new loading position doing it's work! I set up grids to make sure that they're in the blind center.

![image](https://github.com/revanced/revanced-website/assets/84234554/43edffbf-74b7-485d-b7f9-ca1ea506c5be)
