### PR TITLE
feat: remove wavy text decoration

### DIFF
--- a/src/layout/Footer/FooterHost.svelte
+++ b/src/layout/Footer/FooterHost.svelte
@@ -155,9 +155,6 @@
 	}
 
 	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color-two);
 		color: var(--white);
 	}
 

--- a/src/routes/contributors/+page.svelte
+++ b/src/routes/contributors/+page.svelte
@@ -83,9 +83,7 @@
 	}
 
 	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--grey-four);
+		color: var(--white);
 	}
 
 	a:hover::after {

--- a/src/routes/contributors/ContributorPerson.svelte
+++ b/src/routes/contributors/ContributorPerson.svelte
@@ -25,13 +25,6 @@
 		border-bottom: 1px solid var(--grey-three);
 	}
 
-	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color);
-		color: var(--white);
-	}
-
 	h5 {
 		white-space: nowrap;
 		overflow: hidden;

--- a/src/routes/contributors/ContributorSection.svelte
+++ b/src/routes/contributors/ContributorSection.svelte
@@ -79,9 +79,6 @@
 	}
 
 	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color);
 		color: var(--white);
 	}
 

--- a/src/routes/patches/PatchItem.svelte
+++ b/src/routes/patches/PatchItem.svelte
@@ -92,10 +92,7 @@
 	}
 
 	a .patch-info:hover {
-		text-decoration: underline;
 		color: var(--accent-color-two);
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color-two);
 	}
 
 	.info-container {


### PR DESCRIPTION
## About

This PR reverts the design choice of using wavy text decoration. 

## Issue

The reason for that is that it looks out of place and doesn't harmonize with the rest of the website's design. 

## TODO

- [ ] Highlight additionally using `background-color` instead of only `color`
- [ ] Consider wavy footer separator 