### PR TITLE
feat: remove wavy text decoration

### DIFF
--- a/src/layout/Footer/FooterHost.svelte
+++ b/src/layout/Footer/FooterHost.svelte
@@ -155,9 +155,7 @@
 	}
 
 	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color-two);
+		text-decoration: underline var(--accent-color-two);
 		color: var(--white);
 	}
 

--- a/src/routes/contributors/+page.svelte
+++ b/src/routes/contributors/+page.svelte
@@ -83,9 +83,7 @@
 	}
 
 	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--grey-four);
+		text-decoration: underline var(--grey-four);
 	}
 
 	a:hover::after {

--- a/src/routes/contributors/ContributorPerson.svelte
+++ b/src/routes/contributors/ContributorPerson.svelte
@@ -26,9 +26,7 @@
 	}
 
 	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color);
+		text-decoration: underline var(--accent-color);
 		color: var(--white);
 	}
 

--- a/src/routes/contributors/ContributorSection.svelte
+++ b/src/routes/contributors/ContributorSection.svelte
@@ -79,9 +79,7 @@
 	}
 
 	a:hover {
-		text-decoration: underline;
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color);
+		text-decoration: underline var(--accent-color);
 		color: var(--white);
 	}
 

--- a/src/routes/patches/PatchItem.svelte
+++ b/src/routes/patches/PatchItem.svelte
@@ -92,10 +92,8 @@
 	}
 
 	a .patch-info:hover {
-		text-decoration: underline;
+		text-decoration: underline var(--accent-color-two);
 		color: var(--accent-color-two);
-		text-decoration-style: wavy;
-		text-decoration-color: var(--accent-color-two);
 	}
 
 	.info-container {


### PR DESCRIPTION
## About

Accidentally deleted the branch, continuing https://github.com/revanced/revanced-website/pull/120

This PR reverts the design choice of using wavy text decoration. 

## Issue

The reason is that it looks out of place and doesn't harmonize with the rest of the website's design. 

## TODO

- [ ] Highlight additionally using `background-color` instead of only `color`
- [x] Consider wavy footer separator 