### PR TITLE
fix: made modal scrollbar be hidden on all browsers

### DIFF
--- a/src/lib/components/Dialogue.svelte
+++ b/src/lib/components/Dialogue.svelte
@@ -134,6 +134,8 @@
 		padding: 32px;
 		box-shadow: 0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12),
 			0px 2px 4px -1px rgba(0, 0, 0, 0.2);
+		scrollbar-width: none;
+		-ms-overflow-style: none;
 	}
 
 	button {


### PR DESCRIPTION
Opening a new PR. The old one was a mess (#103).