### PR TITLE
fix: show 'Any' for compatibility without explicit versions

### DIFF
--- a/src/routes/patches/PatchItem.svelte
+++ b/src/routes/patches/PatchItem.svelte
@@ -78,6 +78,8 @@
 					/>
 				</Button>
 			{/if}
+		{:else}
+			<li class="patch-info">🎯 Any</li>
 		{/if}
 	</ul>
 


### PR DESCRIPTION
Should it say "All" or "Any"?