### PR TITLE
refactor: Remove redundant CSS rules

### DIFF
--- a/src/routes/donate/TeamMember.svelte
+++ b/src/routes/donate/TeamMember.svelte
@@ -41,11 +41,6 @@
 		&:hover {
 			background-color: var(--grey-six);
 		}
-
-		@media screen and (max-width: 768px) {
-			width: 100%;
-			gap: 1rem;
-		}
 	}
 
 	.member-text {


### PR DESCRIPTION
Removed breakpoint since it does not apply any different styles.
<img width="678" alt="Captura de Tela 2023-10-24 às 16 19 12" src="https://github.com/ReVanced/revanced-website/assets/64154960/51667c8a-6a71-4af0-b1f2-19d21ee6067b">
