### PR TITLE
refactor: Remove redundant CSS rules

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,9 +62,7 @@
 	}
 	@media (max-width: 767px) {
 		.wrappezoid {
-			display: flex;
 			justify-content: center;
-			align-items: center;
 			height: calc(65vh);
 		}
 	}

--- a/src/routes/contributors/+page.svelte
+++ b/src/routes/contributors/+page.svelte
@@ -110,7 +110,6 @@
 	@media screen and (max-width: 767px) {
 		.text-container {
 			padding: 2rem 1.75rem;
-			margin-bottom: 2rem;
 		}
 	}
 </style>


### PR DESCRIPTION
I removed redundant CSS rules in the Homepage and the Contributor page.

Homepage: 
<img width="758" alt="Captura de Tela 2023-10-25 às 20 58 28" src="https://github.com/ReVanced/revanced-website/assets/64154960/fb490bdf-6eaf-436d-a4fc-c3c79a1e7348">

Contributor Page:
<img width="573" alt="Captura de Tela 2023-10-25 às 20 58 55" src="https://github.com/ReVanced/revanced-website/assets/64154960/8a002676-00cf-49ff-8702-c14868b4c554">
<img width="500" alt="Captura de Tela 2023-10-25 às 21 02 15" src="https://github.com/ReVanced/revanced-website/assets/64154960/0f2e2b20-18b4-4d69-88d6-fa474687acc8">



