### PR TITLE
fix: Add missing footer to home page

### DIFF
--- a/src/layout/Hero/HeroImage.svelte
+++ b/src/layout/Hero/HeroImage.svelte
@@ -14,10 +14,10 @@
 	}
 
 	.hero-img {
-		overflow: hidden;
+		overflow:hidden;
 		height: 70vh;
 		max-height: 70rem;
-		z-index: -1;
+		z-index: -2;
 		width: auto;
 		float: right;
 		padding: 0.5rem 0.5rem;
@@ -27,10 +27,10 @@
 	}
 	@media (max-width: 1700px) {
 		.hero-img {
-			position: fixed;
-			height: 100vh;
-			top: 115px;
-			right: 6rem;
+			position: relative;
+			height: 85vh;
+			top: -5px;
+			right: 2rem;
 		}
 	}
 </style>

--- a/src/layout/Hero/HeroImage.svelte
+++ b/src/layout/Hero/HeroImage.svelte
@@ -14,7 +14,7 @@
 	}
 
 	.hero-img {
-		overflow:hidden;
+		overflow: hidden;
 		height: 70vh;
 		max-height: 70rem;
 		z-index: -2;

--- a/src/lib/components/Wave.svelte
+++ b/src/lib/components/Wave.svelte
@@ -4,7 +4,7 @@
 
 <style>
 	svg {
-		position: fixed;
+		position: absolute;
 		z-index: -999;
 		bottom: 0;
 		height: 35vh;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import SocialHost from '$layout/Hero/SocialHost.svelte';
 	import Wave from '$lib/components/Wave.svelte';
 	import Head from '$lib/components/Head.svelte';
+	import FooterHost from '$layout/Footer/FooterHost.svelte';
 </script>
 
 <Head
@@ -127,6 +128,9 @@
 	<SocialHost />
 </main>
 <Wave />
+<div class="footer">
+	<FooterHost />
+</div>
 
 <style>
 	.wrap {
@@ -156,6 +160,11 @@
 		.wrappezoid {
 			justify-content: center;
 			height: calc(65vh);
+		}
+	}
+	@media (max-width: 600px) {
+		.footer {
+			margin-top: 7vh;
 		}
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,9 +2,10 @@
 	import HeroImage from '$layout/Hero/HeroImage.svelte';
 	import Home from '$layout/Hero/HeroSection.svelte';
 	import SocialHost from '$layout/Hero/SocialHost.svelte';
+	import FooterHost from '$layout/Footer/FooterHost.svelte';
 	import Wave from '$lib/components/Wave.svelte';
 	import Head from '$lib/components/Head.svelte';
-	import FooterHost from '$layout/Footer/FooterHost.svelte';
+	
 </script>
 
 <Head


### PR DESCRIPTION
### Description
closes #175
This PR addresses the issue of the missing footer on the home page of the website.

#### Changes Include:
- Added footer component to the home page.
- Adjusted CSS to ensure proper positioning of the footer, hero image and wave.
- Made the changed components responsive.

Please review and provide any feedback.