### PR TITLE
Fix issue with members displaying twice

### DIFF
--- a/src/routes/donate/+page.svelte
+++ b/src/routes/donate/+page.svelte
@@ -119,7 +119,7 @@
 		{#if data.members.length > 0}
 			<section class="team">
 				<!-- randomize team members because equality -->
-				{#each data.members.sort(() => (Math.random() > 0.5 ? -1 : 1)) as member, i}
+				{#each data.members.toSorted(() => (Math.random() > 0.5 ? -1 : 1)) as member, i}
 					<TeamMember {member} {i} />
 				{/each}
 			</section>


### PR DESCRIPTION
So right now there's an issue with members occuring twice.
![image](https://github.com/ReVanced/revanced-website/assets/10727862/10a43d20-330f-44da-bba5-df55ca7329c0)

This probably only happened because of a couple things occurred together (a. using sort which is mutable b. refetching data occasionally c. not using a key), but this PR fixes the issue.

(technically we should just replace this sort with a true shuffle method but it's debatable which one to use)