### PR TITLE
fix: Correct <Button> semantics by not wrapping the content

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -6,23 +6,21 @@
 	export let label = '';
 </script>
 
-<button on:click>
-	{#if href}
-		<a {href} {target} {...$$restProps} class={`button-${type}`} aria-label={label}>
-			{#if icon}
-				<img src="../icons/{icon}.svg" alt={icon} />
-			{/if}
-			<slot />
-		</a>
-	{:else}
-		<div {...$$restProps} class={`button-${type}`} aria-label={label}>
-			{#if icon}
-				<img src="../icons/{icon}.svg" alt={icon} />
-			{/if}
-			<slot />
-		</div>
-	{/if}
-</button>
+{#if href}
+	<a {href} {target} class={`button-${type}`} aria-label={label}>
+		{#if icon}
+			<img src="../icons/{icon}.svg" alt={icon} />
+		{/if}
+		<slot />
+	</a>
+{:else}
+	<button on:click class={`button-${type}`} aria-label={label}>
+		{#if icon}
+			<img src="../icons/{icon}.svg" alt={icon} />
+		{/if}
+		<slot />
+	</button>
+{/if}
 
 <style>
 	button {
@@ -33,7 +31,7 @@
 	}
 
 	a,
-	div {
+	button {
 		min-width: max-content;
 		font-size: 0.95rem;
 		text-decoration: none;
@@ -72,7 +70,7 @@
 		letter-spacing: 0.01rem;
 	}
 
-	div:hover,
+	button:hover,
 	a:hover {
 		filter: brightness(85%);
 	}

--- a/src/routes/download/+page.svelte
+++ b/src/routes/download/+page.svelte
@@ -77,7 +77,6 @@
 			<Button
 				type="text"
 				href={data.assets[0].browser_download_url}
-				download
 				on:click={() => (warningDialogue = false)}>Okay</Button
 			>
 		</Query>
@@ -100,7 +99,6 @@
 					type="filled"
 					icon="download"
 					href={data.assets[0].browser_download_url}
-					download
 				>
 					{data.metadata.tag_name}
 				</Button>


### PR DESCRIPTION
- don't wrap the whole thing in a &lt;button&gt;, instead just have it directly
specific reason: accessibility and cleanness
- remove restProps
specific reason: unused, lets old stuff sneak through
- overall: slightly reduce bundle size