### PR TITLE
chore: Add revanced-bot to the exclusion list

### DIFF
--- a/src/routes/contributors/ContributorSection.svelte
+++ b/src/routes/contributors/ContributorSection.svelte
@@ -10,7 +10,7 @@
 	let expanded = true;
 
 	// Yes
-	let usersIwantToExplodeSoBadly = ['semantic-release-bot'];
+	let usersIwantToExplodeSoBadly = ['semantic-release-bot', 'revanced-bot'];
 	let repo_name = friendlyName(repo);
 </script>
 


### PR DESCRIPTION
Not sure what to label this commit, It's not really considered a "feature" or a bug "fix". I'll use chore as miscellaneous.

@revanced-bot has been engaged in ReVanced Manager repository due to Translation CI but not to the point where it should appear in the contributor list as it only recent (4 days ago as of writing), so it would make sense to add @revanced-bot to the exclusion list like semantic-release-bot is.