### PR TITLE
fix: Only show hover feedback on clickable patch list items

### DIFF
--- a/src/routes/patches/+page.svelte
+++ b/src/routes/patches/+page.svelte
@@ -191,16 +191,14 @@
 			</PackageMenu>
 		</aside>
 
-		<div class="patches-container">
-			{#each filter(data.patches, selectedPkg || '', searchTermFiltered) as patch}
-				<!-- Trigger new animations when package or search changes (I love Svelte) -->
-				{#key selectedPkg || searchTermFiltered}
-					<div in:fly={{ y: 10, easing: quintOut, duration: 750 }}>
-						<PatchItem {patch} bind:showAllVersions />
-					</div>
-				{/key}
-			{/each}
-		</div>
+		{#key selectedPkg || searchTermFiltered}
+			<!-- Trigger new animations when package or search changes (I love Svelte) -->
+			<div class="patches-container" in:fly={{ y: 10, easing: quintOut, duration: 750 }}>
+				{#each filter(data.patches, selectedPkg || '', searchTermFiltered) as patch}
+					<PatchItem {patch} bind:showAllVersions />
+				{/each}
+			</div>
+		{/key}
 	</Query>
 </main>
 <Footer />

--- a/src/routes/patches/PatchItem.svelte
+++ b/src/routes/patches/PatchItem.svelte
@@ -11,10 +11,10 @@
 	let expanded: boolean = false;
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<div
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<svelte:element
+	this={hasPatchOptions ? 'button' : 'div'}
 	class="patch-container"
-	class:expanded={hasPatchOptions}
 	class:rotate={expanded}
 	on:click={() => (expanded = !expanded)}
 >
@@ -103,7 +103,7 @@
 			</div>
 		</span>
 	{/if}
-</div>
+</svelte:element>
 
 <style lang="scss">
 	h3 {
@@ -167,6 +167,13 @@
 		background-color: var(--grey-six);
 		padding: 1.25rem;
 		border-radius: 12px;
+	}
+	button.patch-container {
+		cursor: pointer;
+
+		display: block;
+		border: none;
+		text-align: left;
 
 		&:active {
 			filter: brightness(1.15);
@@ -195,10 +202,6 @@
 
 	.rotate .expand-arrow {
 		transform: rotate(180deg);
-	}
-
-	.expanded {
-		cursor: pointer;
 	}
 
 	.option {


### PR DESCRIPTION
- right now, all patches look clickable, and no patches can be tabbed to.
- with this, we make expandable patches buttons (can be tabbed to), and only apply the hover animations to those. this makes it more clear when a patch can be expanded.
- we also uplevel the animation wrapper div because it was causing the widths to be odd, probably also improving perf.