### PR TITLE
fix: Remove unnecessary app version sorting

### DIFF
--- a/src/routes/patches/PatchItem.svelte
+++ b/src/routes/patches/PatchItem.svelte
@@ -59,8 +59,6 @@
 						const coercedA = coerce(a);
 						const coercedB = coerce(b);
 						if (coercedA && coercedB) return compare(coercedA, coercedB);
-						else if (!coercedA && !coercedB) return 0;
-						else return !coercedA ? 1 : -1;
 					})
 					.reverse() as version}
 					<li class="patch-info">

--- a/src/routes/patches/PatchItem.svelte
+++ b/src/routes/patches/PatchItem.svelte
@@ -53,14 +53,7 @@
 		<!-- Should this be hardcoded to get the version of the first package?  -->
 		{#if patch.compatiblePackages?.length && patch.compatiblePackages[0].versions?.length}
 			{#if showAllVersions}
-				{#each patch.compatiblePackages[0].versions
-					.slice()
-					.sort((a, b) => {
-						const coercedA = coerce(a);
-						const coercedB = coerce(b);
-						if (coercedA && coercedB) return compare(coercedA, coercedB);
-					})
-					.reverse() as version}
+				{#each patch.compatiblePackages[0].versions.reverse() as version}
 					<li class="patch-info">
 						🎯 {version}
 					</li>


### PR DESCRIPTION
I couldn't figure out why these lines of code were here, or if removing them would effect anything, but it seems to work perfectly fine
Closes #238