### PR TITLE
fix: Use correct word break for patch option descriptions

### DIFF
--- a/src/routes/patches/PatchItem.svelte
+++ b/src/routes/patches/PatchItem.svelte
@@ -110,7 +110,7 @@
 
 	#option-description {
 		white-space: pre-wrap;
-		word-break: break-all;
+		word-break: break-word;
 	}
 
 	#option-title {


### PR DESCRIPTION
fix #250