### PR TITLE
fix: Only render GPG key tooltip and icon if team member has one

### DIFF
--- a/src/routes/donate/TeamMember.svelte
+++ b/src/routes/donate/TeamMember.svelte
@@ -28,21 +28,23 @@
 				<h4>{member.name}</h4>
 			</a>
 			<div class="verified-badge">
-				<ToolTip
-					content="<p>GPG key ID:</p> <a class='gpg-url' href={member.gpg_key
-						.url} rel='noreferrer' target='_blank'>{member.gpg_key.id}</a>"
-					html={true}
-				>
-					<div class="desktop">
-						<a href={member.gpg_key.url} rel="noreferrer" target="_blank">
+				{#if member.gpg_key}
+					<ToolTip
+						content="<p>GPG key ID:</p> <a class='gpg-url' href={member.gpg_key
+							.url} rel='noreferrer' target='_blank'>{member.gpg_key.id}</a>"
+						html={true}
+					>
+						<div class="desktop">
+							<a href={member.gpg_key.url} rel="noreferrer" target="_blank">
+								<CheckDecagramOutline size="20px" color="var(--secondary)" />
+							</a>
+						</div>
+						<div class="mobile">
 							<CheckDecagramOutline size="20px" color="var(--secondary)" />
-						</a>
-					</div>
-					<div class="mobile">
-						<CheckDecagramOutline size="20px" color="var(--secondary)" />
-						<h5>GPG key</h5>
-					</div>
-				</ToolTip>
+							<h5>GPG key</h5>
+						</div>
+					</ToolTip>
+				{/if}
 			</div>
 		</div>
 		{#if member.bio}

--- a/src/routes/donate/TeamMember.svelte
+++ b/src/routes/donate/TeamMember.svelte
@@ -27,8 +27,8 @@
 			<a href={member.url} rel="noreferrer" target="_blank" in:fly|global={transitionOptions}>
 				<h4>{member.name}</h4>
 			</a>
-			<div class="verified-badge">
-				{#if member.gpg_key}
+			{#if member.gpg_key}
+				<div class="verified-badge">
 					<ToolTip
 						content="<p>GPG key ID:</p> <a class='gpg-url' href={member.gpg_key
 							.url} rel='noreferrer' target='_blank'>{member.gpg_key.id}</a>"
@@ -44,8 +44,8 @@
 							<h5>GPG key</h5>
 						</div>
 					</ToolTip>
-				{/if}
-			</div>
+				</div>
+			{/if}
 		</div>
 		{#if member.bio}
 			<h6>{member.bio}</h6>


### PR DESCRIPTION
Website is crashing right now if the `/donate` page is viewed, due to a team member not having a GPG key. This will render the GPG checkmark icon and tooltip only if the team member has one set.
It is useful to have this check in case it happens again in the future for even longer periods maybe.